### PR TITLE
ANDROID: xattr: Pass EOPNOTSUPP to permission2

### DIFF
--- a/fs/sdcardfs/inode.c
+++ b/fs/sdcardfs/inode.c
@@ -627,6 +627,8 @@ static int sdcardfs_permission(struct vfsmount *mnt, struct inode *inode, int ma
 	struct inode tmp;
 	struct sdcardfs_inode_data *top = top_data_get(SDCARDFS_I(inode));
 
+	if (IS_ERR(mnt))
+		return PTR_ERR(mnt);
 	if (!top)
 		return -EINVAL;
 

--- a/fs/xattr.c
+++ b/fs/xattr.c
@@ -70,7 +70,7 @@ xattr_permission(struct inode *inode, const char *name, int mask)
 			return -EPERM;
 	}
 
-	return inode_permission(inode, mask);
+	return inode_permission2(ERR_PTR(-EOPNOTSUPP), inode, mask);
 }
 
 /**


### PR DESCRIPTION
The permission call for xattr operations happens regardless of
whether or not the xattr functions are implemented.

The xattr functions currently don't have support for permission2.
Passing EOPNOTSUPP as the mount point in xattr_permission allows
us to return EOPNOTSUPP early in permission2, if the filesystem
supports it.

Change-Id: I9d07e4cd633cf40af60450ffbff7ac5c1b4e8c2c
Signed-off-by: Daniel Rosenberg <drosen@google.com>
Bug: 35848445