### PR TITLE
ARM: dts: msm8996-xiaomi: Set /vendor block device

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8996-xiaomi-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996-xiaomi-common.dtsi
@@ -1964,7 +1964,9 @@
 &firmware {
 	android {
 		fstab {
-			/delete-node/ vendor;
+			vendor {
+				dev = "/dev/block/platform/soc/624000.ufshc/by-name/cust";
+			};
 			system {
 				dev = "/dev/block/platform/soc/624000.ufshc/by-name/system";
 			};


### PR DESCRIPTION
 * Turn the partition used by Xiaomi to ship MIUI regional
   customizations into something more useful for us. This mounts /cust
   partition as /vendor, allowing us to build a dedicated vendor image.

Change-Id: Ie4a9ea12085d5ee19e9ec422fb32dce7b230ac2f