### PR TITLE
ft5x46: Allow disabling ft8716 firmware updates

### DIFF
--- a/drivers/input/touchscreen/ft5x46/Kconfig
+++ b/drivers/input/touchscreen/ft5x46/Kconfig
@@ -57,3 +57,10 @@ config TOUCHSCREEN_FT5X46P_PROXIMITY
 	default n
 	help
 	 focaltech touch proximity enable.
+
+config TOUCHSCREEN_FT8716_DISABLE_FW_UPDATE
+	bool "disable ft8716 firmware updates"
+	depends on TOUCHSCREEN_FT5X46
+	default n
+	help
+	 Say Y here to disable ft8716 firmware updates.

--- a/drivers/input/touchscreen/ft5x46/ft5x46_ts.c
+++ b/drivers/input/touchscreen/ft5x46/ft5x46_ts.c
@@ -84,6 +84,12 @@
 /* ft8716 firmware upgrade definition */
 #define FT8716_FIRMWARE_VERION		0x10e
 
+#ifdef CONFIG_TOUCHSCREEN_FT8716_DISABLE_FW_UPDATE
+#define FT8716_DISABLE_FW_UPDATE	1
+#else
+#define FT8716_DISABLE_FW_UPDATE	0
+#endif
+
 /* ft5x0x firmware upgrade definition */
 #define FT5X0X_FIRMWARE_TAIL		(-8) /* base on the end of firmware */
 #define FT5X0X_FIRMWARE_VERION		(-2)
@@ -1322,7 +1328,7 @@ static int ft8716_load_firmware(struct ft5x46_data *ft5x46,
 
 	/* step 1: check firmware id is different */
 
-	if (id == firmware->data[FT8716_FIRMWARE_VERION]) {
+	if (id == firmware->data[FT8716_FIRMWARE_VERION] || FT8716_DISABLE_FW_UPDATE) {
 		ft8716_reset_firmware(ft5x46);
 		return 0;
 	}


### PR DESCRIPTION
Updating touch firmware causes touch to stop working
in some cases, e.g. in TWRP.

Allow the feature to be disabled.

Change-Id: I60d2a15762ff0fa4fdb4e3062f834bdeb328ca13